### PR TITLE
Refactor/search page > 검색페이지에서 영화상세페이지 경로 매핑 로직 수정

### DIFF
--- a/packages/web/src/components/LoadingSpinner.tsx
+++ b/packages/web/src/components/LoadingSpinner.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import '../styles/LoadingSpinner.css';
+
+interface LoadingSpinnerProps {
+  size?: 'small' | 'medium' | 'large';
+  color?: string;
+}
+
+const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ 
+  size = 'medium',
+  color = '#FF0558' // 왓챠 핑크 컬러
+}) => {
+  return (
+    <div className="loading-spinner-container">
+      <div 
+        className={`loading-spinner ${size}`}
+        style={{ borderTopColor: color }}
+      />
+    </div>
+  );
+};
+
+export default LoadingSpinner; 

--- a/packages/web/src/components/movie/MovieMainInfo.tsx
+++ b/packages/web/src/components/movie/MovieMainInfo.tsx
@@ -1,29 +1,41 @@
 import React from 'react';
 import ActionButton from './ActionButton';
 
-const MovieMainInfo = ({ movie }: { movie: any }) => (
-  <div className="movie-main-info">
-    <div className="movie-title-row">
-      <span className="movie-age-badge">ALL</span>
-      <h1>{movie.title}</h1>
+const MovieMainInfo = ({ movie }: { movie: any }) => {
+  const runtime =
+    movie.runtime !== undefined && movie.runtime !== null
+      ? movie.runtime
+      : Array.isArray(movie.episode_run_time) && movie.episode_run_time.length > 0
+        ? movie.episode_run_time[0]
+        : undefined;
+
+  return (
+    <div className="movie-main-info">
+      <div className="movie-title-row">
+        <span className="movie-age-badge">ALL</span>
+        <h1>{movie.title || movie.name}</h1>
+      </div>
+      <div className="movie-meta">
+        <span>평균 {movie.vote_average?.toFixed(1)}</span>
+        <span>
+          {runtime !== undefined && runtime !== null
+            ? `${Math.floor(runtime / 60)}시간 ${runtime % 60}분`
+            : <span className="runtime-missing">상영시간 정보 없음</span>}
+        </span>
+        <span>{movie.genres?.map((g: any) => g.name).join(', ')}</span>
+        <span>{movie.production_countries?.[0]?.name}</span>
+      </div>
+      <div className="movie-summary">{movie.overview}</div>
+      <div className="movie-buttons">
+        <ActionButton className="primary">구매하기</ActionButton>
+        <ActionButton className="secondary">선물하기</ActionButton>
+      </div>
+      <div className="movie-alerts">
+        <div>개별 구매로 감상할 수 있는 콘텐츠예요</div>
+        <div>5/21(수)까지 대여, 소장 20% 할인!</div>
+      </div>
     </div>
-    <div className="movie-meta">
-      <span>평균 {movie.vote_average?.toFixed(1)}</span>
-      <span>{movie.release_date?.slice(0, 4)}</span>
-      <span>{Math.floor(movie.runtime / 60)}시간 {movie.runtime % 60}분</span>
-      <span>{movie.genres?.map((g: any) => g.name).join(', ')}</span>
-      <span>{movie.production_countries?.[0]?.name}</span>
-    </div>
-    <div className="movie-summary">{movie.overview}</div>
-    <div className="movie-buttons">
-      <ActionButton className="primary">구매하기</ActionButton>
-      <ActionButton className="secondary">선물하기</ActionButton>
-    </div>
-    <div className="movie-alerts">
-      <div>개별 구매로 감상할 수 있는 콘텐츠예요</div>
-      <div>5/21(수)까지 대여, 소장 20% 할인!</div>
-    </div>
-  </div>
-);
+  );
+};
 
 export default MovieMainInfo; 

--- a/packages/web/src/pages/MovieDetailPage.tsx
+++ b/packages/web/src/pages/MovieDetailPage.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import MovieMainInfo from '../components/movie/MovieMainInfo';
@@ -7,6 +8,7 @@ import PeopleList from '../components/movie/PeopleList';
 import ReviewList from '../components/movie/ReviewList';
 import RelatedVideos from '../components/movie/RelatedVideos';
 import '../styles/MovieDetailPage.css';
+import LoadingSpinner from '../components/LoadingSpinner';
 
 const TMDB_API_KEY = process.env.REACT_APP_TMDB_API_KEY;
 
@@ -72,11 +74,8 @@ const MovieDetailPage = () => {
   });
   const reviews = reviewsData?.results || [];
 
-  // 라우팅 파라미터 id와 API로 받아온 movie.id를 콘솔에 출력
-  console.log('라우팅 파라미터 id:', id);
-  console.log('API로 받아온 movie.id:', movie?.id);
 
-  if (isLoading) return <div>로딩 중...</div>;
+  if (isLoading) return <LoadingSpinner size="large" />;
   if (error || !movie) return <div>영화 정보를 불러올 수 없습니다.</div>;
 
   const directors = movie.credits?.crew?.filter((person: any) => person.job === 'Director') || [];

--- a/packages/web/src/pages/RecommendPage.tsx
+++ b/packages/web/src/pages/RecommendPage.tsx
@@ -1,39 +1,36 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Navigation, Autoplay } from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import '../styles/RecommendPage.css';
 import MovieCard from '../components/MovieCard';
+import LoadingSpinner from '../components/LoadingSpinner';
 import { fetchTrendingMovies } from '../utils/api';
-import { useNavigate } from 'react-router-dom';
 
 interface Movie {
   id: number;
   title: string;
-  overview: string;
+  poster_path: string;
   backdrop_path: string;
+  overview: string;
+  vote_average: number;
+  release_date: string;
 }
 
-const RecommendPage = () => {
-  const [movies, setMovies] = useState<Movie[]>([]);
+const RecommendPage: React.FC = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const prevRef = useRef<HTMLDivElement>(null);
   const nextRef = useRef<HTMLDivElement>(null);
   const swiperRef = useRef<any>(null);
   const navigate = useNavigate();
+  const { data: movies, isLoading, error } = useQuery<Movie[]>({
+    queryKey: ['trendingMovies'],
+    queryFn: fetchTrendingMovies
+  });
 
-  useEffect(() => {
-    const loadMovies = async () => {
-      const data = await fetchTrendingMovies();
-      // overview가 비어있지 않은 영화만 필터링
-      const filteredMovies = data.filter((movie: Movie) => movie.overview && movie.overview.trim() !== '');
-      setMovies(filteredMovies);
-    };
-    loadMovies();
-  }, []);
-
-  // Swiper navigation 버튼을 동적으로 연결
   useEffect(() => {
     if (
       swiperRef.current &&
@@ -53,47 +50,55 @@ const RecommendPage = () => {
     setCurrentIndex(swiper.realIndex);
   };
 
-  const nextMovie = movies.length > 0 ? movies[(currentIndex + 1) % movies.length] : null;
+  const nextMovie = movies && movies.length > 0 ? movies[(currentIndex + 1) % movies.length] : null;
 
   return (
-    <div className="recommended-container">
-      <div className="recommend-custom-layout">
-        <div className="swiper-button-prev" ref={prevRef}></div>
-        <div className="swiper-button-next" ref={nextRef}></div>
-        <div className="main-poster-area">
-          <Swiper
-            modules={[Navigation, Autoplay]}
-            onSwiper={(swiper) => {
-              swiperRef.current = swiper;
-            }}
-            loop={true}
-            autoplay={{
-              delay: 3000,
-              disableOnInteraction: false,
-            }}
-            slidesPerView={1}
-            centeredSlides={true}
-            onSlideChange={handleSlideChange}
-          >
-            {movies.map((movie) => (
-              <SwiperSlide key={movie.id}>
-                <MovieCard movie={movie} onClick={() => navigate(`/movies/${movie.id}`)} />
-              </SwiperSlide>
-            ))}
-          </Swiper>
-        </div>
-        <div className="next-poster-gap" />
-        {nextMovie && (
-          <div className="next-poster-preview-area" onClick={() => navigate(`/movies/${nextMovie.id}`)} style={{ cursor: 'pointer' }}>
-            <img
-              src={`https://image.tmdb.org/t/p/original${nextMovie.backdrop_path}`}
-              alt={nextMovie.title}
-              className="next-poster-img-crop"
-            />
-            <div className="next-poster-title">{nextMovie.title}</div>
+    <div className="recommend-page">
+      {isLoading ? (
+        <LoadingSpinner size="large" />
+      ) : error ? (
+        <div>추천 영화를 불러올 수 없습니다.</div>
+      ) : (
+        <div className="recommended-container">
+          <div className="recommend-custom-layout">
+            <div className="swiper-button-prev" ref={prevRef}></div>
+            <div className="swiper-button-next" ref={nextRef}></div>
+            <div className="main-poster-area">
+              <Swiper
+                modules={[Navigation, Autoplay]}
+                onSwiper={(swiper) => {
+                  swiperRef.current = swiper;
+                }}
+                loop={true}
+                autoplay={{
+                  delay: 3000,
+                  disableOnInteraction: false,
+                }}
+                slidesPerView={1}
+                centeredSlides={true}
+                onSlideChange={handleSlideChange}
+              >
+                {movies?.map((movie) => (
+                  <SwiperSlide key={movie.id}>
+                    <MovieCard movie={movie} onClick={() => navigate(`/movies/${movie.id}`)} />
+                  </SwiperSlide>
+                ))}
+              </Swiper>
+            </div>
+            <div className="next-poster-gap" />
+            {nextMovie && (
+              <div className="next-poster-preview-area" onClick={() => navigate(`/movies/${nextMovie.id}`)} style={{ cursor: 'pointer' }}>
+                <img
+                  src={`https://image.tmdb.org/t/p/original${nextMovie.backdrop_path}`}
+                  alt={nextMovie.title}
+                  className="next-poster-img-crop"
+                />
+                <div className="next-poster-title">{nextMovie.title}</div>
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/web/src/pages/SearchPage.tsx
+++ b/packages/web/src/pages/SearchPage.tsx
@@ -57,6 +57,11 @@ const SearchPage: React.FC = () => {
     : trending[activeIdx]?.backdrop_path || trending[activeIdx]?.poster_path;
 
   const handleTitleClick = (item: any) => {
+    console.log('클릭한 item:', {
+      id: item.id,
+      title: item.title,
+      media_type: item.media_type
+    });
     const mediaType = item.media_type || 'movie';
     navigate(`/detail/${mediaType}/${item.id}`);
   };

--- a/packages/web/src/styles/LoadingSpinner.css
+++ b/packages/web/src/styles/LoadingSpinner.css
@@ -1,0 +1,38 @@
+.loading-spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  min-height: 100px;
+}
+
+.loading-spinner {
+  border: 3px solid rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  border-top: 3px solid;
+  animation: spin 1s linear infinite;
+}
+
+.loading-spinner.small {
+  width: 20px;
+  height: 20px;
+  border-width: 2px;
+}
+
+.loading-spinner.medium {
+  width: 30px;
+  height: 30px;
+  border-width: 3px;
+}
+
+.loading-spinner.large {
+  width: 50px;
+  height: 50px;
+  border-width: 4px;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+} 

--- a/packages/web/src/styles/RecommendPage.css
+++ b/packages/web/src/styles/RecommendPage.css
@@ -205,3 +205,7 @@
 .recommend-custom-layout:hover .swiper-button-next {
   opacity: 1;
 }
+
+.runtime-missing {
+  color: #aaa;
+}

--- a/packages/web/src/styles/SearchPage.css
+++ b/packages/web/src/styles/SearchPage.css
@@ -242,7 +242,7 @@
   flex: 1;
   position: relative;
   min-width: 0;
-  height: 320px;
+  height: 441px;
   margin-right: 20px;
   display: flex;
   align-items: flex-start;
@@ -252,7 +252,7 @@
 .trending-main-poster {
   width: 100%;
   max-width: 600px;
-  height: 320px;
+  height: 441px;
   object-fit: cover;
   border-radius: 0 0 0 0;
   position: absolute;


### PR DESCRIPTION
📝 요약(Summary)

- 검색 페이지에서 영화/TV/인물 클릭 시 상세페이지로 이동하는 경로 매핑 로직을 수정했습니다.
- media_type에 따라 영화는 /detail/movie/:id, TV는 /detail/tv/:id로 이동하도록 개선했습니다.
- MovieDetailPage에서 media_type에 따라 영화/TV API를 분기 호출하여 상세정보가 올바르게 표시됩니다.
- 잘못된 id, media_type으로 인한 상세페이지 오류 및 데이터 불일치 문제를 해결했습니다.

🛠️ PR 유형
어떤 변경 사항이 있나요?

[x] 버그 수정
[x] 코드 리팩토링
[ ] 새로운 기능 추가
[ ] CSS 등 사용자 UI 디자인 변경
[ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
[ ] 주석 추가 및 수정
[ ] 문서 수정
[ ] 테스트 추가, 테스트 리팩토링
[ ] 빌드 부분 혹은 패키지 매니저 수정
[ ] 파일 혹은 폴더명 수정
[ ] 파일 혹은 폴더 삭제

💬 공유사항 to 리뷰어

검색 결과에서 영화/TV/인물 클릭 시 상세페이지 라우팅이 올바르게 동작하는지 중점적으로 확인 부탁드립니다.
MovieDetailPage의 media_type 분기 처리 및 데이터 매핑에 대한 추가 의견 환영합니다.

✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
[x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
[x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).